### PR TITLE
fix field-comment option toggle

### DIFF
--- a/src/sphinxcontrib/ros/__init__.py
+++ b/src/sphinxcontrib/ros/__init__.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 
 import pkg_resources
 from sphinx.domains import Domain, ObjType
-from sphinx.locale import l_
+from sphinx.locale import _
 from sphinx.roles import XRefRole
 from sphinx.util.nodes import make_refnode
 
@@ -29,11 +29,11 @@ class ROSDomain(Domain):
     name = 'ros'
     label = 'ros'
     object_types = {
-        'package': ObjType(l_('package'), 'pkg'),
-        'message': ObjType(l_('message'), 'msg'),
-        'service': ObjType(l_('service'), 'srv'),
-        'action': ObjType(l_('action'), 'action'),
-        'node': ObjType(l_('node'), 'node'),
+        'package': ObjType(_('package'), 'pkg'),
+        'message': ObjType(_('message'), 'msg'),
+        'service': ObjType(_('service'), 'srv'),
+        'action': ObjType(_('action'), 'action'),
+        'node': ObjType(_('node'), 'node'),
     }
     directives = {
         'package': ROSPackage,

--- a/src/sphinxcontrib/ros/api.py
+++ b/src/sphinxcontrib/ros/api.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 
 from docutils.parsers.rst import directives
 from docutils import nodes
-from sphinx.locale import l_
+from sphinx.locale import _
 from sphinx.util.docfields import GroupedField, TypedField
 
 from .base import ROSObjectDescription
@@ -25,41 +25,41 @@ class ROSAPI(ROSObjectDescription):
     }
     doc_field_types = [
         TypedField('pub',
-                   label=l_('Published Topics'),
+                   label=_('Published Topics'),
                    names=('pub',),
                    typerolename='msg', typenames=('pub-type',)),
         TypedField('sub',
-                   label=l_('Subscribed Topics'),
+                   label=_('Subscribed Topics'),
                    names=('sub',),
                    typerolename='msg', typenames=('sub-type',)),
-        TypedField('srv', label=l_('Services'),
+        TypedField('srv', label=_('Services'),
                    names=('srv',),
                    typerolename='srv', typenames=('srv-type',)),
         TypedField('srv_called',
-                   label=l_('Services Called'),
+                   label=_('Services Called'),
                    names=('srv_called',),
                    typerolename='srv', typenames=('srv_called-type',)),
         TypedField('action',
-                   label=l_('Actions'),
+                   label=_('Actions'),
                    names=('action',),
                    typerolename='action', typenames=('action-type',)),
         TypedField('action_called',
-                   label=l_('Actions Called'),
+                   label=_('Actions Called'),
                    names=('action_called',),
                    typerolename='action', typenames=('action_called-type',)),
         TypedField('param',
-                   label=l_('Parameters'),
+                   label=_('Parameters'),
                    names=('param',),
                    typenames=('param-type',)),
         TypedField('param_set',
-                   label=l_('Parameters Set'),
+                   label=_('Parameters Set'),
                    names=('param_set',),
                    typenames=('param_set-type',)),
         GroupedField('param-default',
-                     label=l_('Parameters Default Value'),
+                     label=_('Parameters Default Value'),
                      names=('param-default',)),
         GroupedField('param_set-default',
-                     label=l_('Parameters Set Default Value'),
+                     label=_('Parameters Set Default Value'),
                      names=('param_set-default',)),
     ]
     doc_merge_fields = {

--- a/src/sphinxcontrib/ros/message.py
+++ b/src/sphinxcontrib/ros/message.py
@@ -333,7 +333,7 @@ class ROSAutoType(ROSType):
 
         # fields
         options = self.options.get('field-comment', '')
-        field_comment_option = options.encode('ascii').lower().split()
+        field_comment_option = options.lower().split()
         content = self.type_file.make_docfields(field_groups,
                                                 field_comment_option)
 
@@ -355,7 +355,7 @@ class ROSAutoType(ROSType):
                         pass
                     else:
                         raise ValueError(
-                            "unkonwn option {0} in "
+                            "unknown option {0} in "
                             "the description option".format(option))
                 blocks = desc_blocks[(int(first) if first else None):
                                      (int(second) if second else None)]

--- a/src/sphinxcontrib/ros/message.py
+++ b/src/sphinxcontrib/ros/message.py
@@ -13,7 +13,7 @@ from __future__ import print_function
 import os
 import codecs
 import re
-from sphinx.locale import l_
+from sphinx.locale import _
 from docutils import nodes
 from docutils.statemachine import StringList
 from docutils.parsers.rst import directives
@@ -214,20 +214,20 @@ class ROSFieldGroupType(object):
     def get_doc_field_types(self):
         return [
             TypedField(self.field_name,
-                       label=l_(self.field_label),
+                       label=_(self.field_label),
                        names=(self.field_name,),
                        typerolename='msg',
                        typenames=('{0}-{1}'.format(self.field_name,
                                                    TYPE_SUFFIX),)),
             TypedField(self.constant_name,
-                       label=l_(self.constant_label),
+                       label=_(self.constant_label),
                        names=(self.constant_name,),
                        typerolename='msg',
                        typenames=('{0}-{1}'.format(self.constant_name,
                                                    TYPE_SUFFIX),)),
             GroupedField('{0}-{1}'.format(self.constant_name,
                                           VALUE_SUFFIX),
-                         label=l_('{0} (Value)'.format(self.constant_label)),
+                         label=_('{0} (Value)'.format(self.constant_label)),
                          names=('{0}-{1}'.format(self.constant_name,
                                                  VALUE_SUFFIX),)),
             ]

--- a/src/sphinxcontrib/ros/package.py
+++ b/src/sphinxcontrib/ros/package.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 
 from docutils.parsers.rst import directives
 from docutils.statemachine import StringList
-from sphinx.locale import l_
+from sphinx.locale import _
 from sphinx.util.docfields import Field
 try:
     unicode
@@ -109,11 +109,11 @@ class ROSPackage(ROSObjectDescription):
     )
     doc_field_types = [
         GroupedFieldNoArg(attr[:-1],
-                          label=l_(''.join(w.title()
+                          label=_(''.join(w.title()
                                            for w in attr.split('_'))),
                           names=(attr[:-1],))
         if attr.endswith('s') else
-        Field(attr, label=l_(attr.title()), names=(attr,), has_arg=False)
+        Field(attr, label=_(attr.title()), names=(attr,), has_arg=False)
         for attr in package_attrs
     ]
 


### PR DESCRIPTION
最近の環境でfield-commentオプションがうまく動作しなかったので修正しました。

sphinxのアップデートのためなのか、python3の挙動のせいなのかはよくわかっていません。